### PR TITLE
Fix : stamp assembly version same as pakage version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       run: dotnet restore
 
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release --no-restore -p:Version=${{ env.MAJOR_MINOR_VERSION }}${{ github.run_number }}
 
     # Run the tests, ideally should stop here if a fail and also publish results as artifacts
     - name: Test


### PR DESCRIPTION
On version 7.0.X we stamp version with the same version as package version and we did not do that in GitHub action
New  7.1.X
![image](https://user-images.githubusercontent.com/488464/192087604-9eb2dc6e-373a-4104-83a4-94b34da0525d.png)

Old 7.0.X
![image](https://user-images.githubusercontent.com/488464/192087630-c044eff1-a86d-42b4-92fe-4220e52e353f.png)
